### PR TITLE
Add explicit include for TString.h to avoid build failure with ROOT v6.24

### DIFF
--- a/src/anlib/ANL4DVector.h
+++ b/src/anlib/ANL4DVector.h
@@ -23,9 +23,8 @@
 //
 #include <iostream>
 #include "TLorentzVector.h"
-#if 1
 #include "TMath.h"
-#endif
+#include "TString.h"
 #include "TAttLockable.h"
 //#include "ANL3DVector.h"
 


### PR DESCRIPTION


The v6.24 release of ROOT has cleaned up some internal includes, which is why physsim fails to build:

```
     119    In file included from input_line_9:21:
  >> 120    /tmp/gitlab-runner/spack-stage/spack-stage-physsim-0.4.1-7qxy6x37c6
            vzyadt2fgqjokwjdmzngja/spack-src/src/anlib/ANL4DVector.h:146:10: er
            ror: 'TString' is an incomplete type
     121         if (TString(opt).Contains("Detailed")) {
```

BEGINRELEASENOTES
- Add explicit include for TString.h to avoid build failure with ROOT v6.24

ENDRELEASENOTES