### PR TITLE
[wip] Update clicdp nightlies and use key4hep-build action

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -5,37 +5,14 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
+      matrix:
+        build_type: ["release", "nightly"]
+        image: ["alma9", "ubuntu22", "centos7"]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: actions/checkout@v4
+    - uses: key4hep/key4hep-actions/key4hep-build@main
       with:
-        container: centos7
-        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
-        run: |
-          mkdir build
-          cd build
-          echo "::group::Run CMake"
-          cmake -GNinja \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
-            -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_INSTALL_PREFIX=../install \
-            ..
-          echo "::endgroup::" && echo "::group::Build"
-          ninja -k0
-          echo "::endgroup::" && echo "::group::Install"
-          ninja install
-          echo "::endgroup::" && echo "::group::Build example processors"
-          cd ../install
-          export CMAKE_PREFIX_PATH=$(pwd):${CMAKE_PREFIX_PATH}
-          cd ../example_stdhep
-          mkdir build
-          cd build
-          cmake -GNinja \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
-            -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_INSTALL_PREFIX=../install \
-            ..
-          ninja -k0
+        build_type: ${{ matrix.build_type }}
+        image: ${{ matrix.image }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,12 +7,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPILER: [gcc10, clang11]
-        LCG: [100]
+        COMPILER: [gcc11]
+        LCG: [104]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/${{ matrix.LCG }}/nightly/x86_64-centos7-${{ matrix.COMPILER }}-opt"

--- a/example_stdhep/CMakeLists.txt
+++ b/example_stdhep/CMakeLists.txt
@@ -22,6 +22,15 @@ FIND_PACKAGE( ILCUTIL REQUIRED COMPONENTS ILCSOFT_CMAKE_MODULES )
 FIND_PACKAGE( ROOT 6.14 REQUIRED )
 FIND_PACKAGE( Physsim REQUIRED)
 
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+# Prevent CMake falls back to the latest standard the compiler does support
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Disables the use of compiler-specific extensions, hence makes sure the code
+# works for a wider range of compilers
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+
 # load default settings from ILCSOFT_CMAKE_MODULES
 INCLUDE( ilcsoft_default_settings )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Update CI to run on latest clicdp nightlies and use the key4hep-build action

ENDRELEASENOTES